### PR TITLE
Add support for dynamic sectors spanning multiple logical blocks

### DIFF
--- a/PS2ImageMaker.sln
+++ b/PS2ImageMaker.sln
@@ -16,6 +16,8 @@ Global
 		Debug|x86 = Debug|x86
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
+		RelWithDebugInfo|x64 = RelWithDebugInfo|x64
+		RelWithDebugInfo|x86 = RelWithDebugInfo|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1E7A9D11-3983-4592-9BF7-4313C1FC894C}.Debug|x64.ActiveCfg = Debug|x64
@@ -26,6 +28,10 @@ Global
 		{1E7A9D11-3983-4592-9BF7-4313C1FC894C}.Release|x64.Build.0 = Release|x64
 		{1E7A9D11-3983-4592-9BF7-4313C1FC894C}.Release|x86.ActiveCfg = Release|Win32
 		{1E7A9D11-3983-4592-9BF7-4313C1FC894C}.Release|x86.Build.0 = Release|Win32
+		{1E7A9D11-3983-4592-9BF7-4313C1FC894C}.RelWithDebugInfo|x64.ActiveCfg = RelWithDebugInfo|x64
+		{1E7A9D11-3983-4592-9BF7-4313C1FC894C}.RelWithDebugInfo|x64.Build.0 = RelWithDebugInfo|x64
+		{1E7A9D11-3983-4592-9BF7-4313C1FC894C}.RelWithDebugInfo|x86.ActiveCfg = RelWithDebugInfo|Win32
+		{1E7A9D11-3983-4592-9BF7-4313C1FC894C}.RelWithDebugInfo|x86.Build.0 = RelWithDebugInfo|Win32
 		{1EE3357F-ADB1-4B56-B430-0F337B53FEF4}.Debug|x64.ActiveCfg = Debug|x64
 		{1EE3357F-ADB1-4B56-B430-0F337B53FEF4}.Debug|x64.Build.0 = Debug|x64
 		{1EE3357F-ADB1-4B56-B430-0F337B53FEF4}.Debug|x86.ActiveCfg = Debug|Win32
@@ -34,6 +40,10 @@ Global
 		{1EE3357F-ADB1-4B56-B430-0F337B53FEF4}.Release|x64.Build.0 = Release|x64
 		{1EE3357F-ADB1-4B56-B430-0F337B53FEF4}.Release|x86.ActiveCfg = Release|Win32
 		{1EE3357F-ADB1-4B56-B430-0F337B53FEF4}.Release|x86.Build.0 = Release|Win32
+		{1EE3357F-ADB1-4B56-B430-0F337B53FEF4}.RelWithDebugInfo|x64.ActiveCfg = RelWithDebugInfo|x64
+		{1EE3357F-ADB1-4B56-B430-0F337B53FEF4}.RelWithDebugInfo|x64.Build.0 = RelWithDebugInfo|x64
+		{1EE3357F-ADB1-4B56-B430-0F337B53FEF4}.RelWithDebugInfo|x86.ActiveCfg = RelWithDebugInfo|Win32
+		{1EE3357F-ADB1-4B56-B430-0F337B53FEF4}.RelWithDebugInfo|x86.Build.0 = RelWithDebugInfo|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/PS2ImageMaker/Directory.cpp
+++ b/PS2ImageMaker/Directory.cpp
@@ -243,3 +243,17 @@ unsigned int FileTreeNode::get_directory_records_space()
 	}
 	return std::ceil(space / 2048.0);
 }
+
+unsigned int FileTreeNode::get_file_identifiers_space()
+{
+	unsigned int space = 0;
+	if (this->file->IsDirectory()) {
+		space = 0x60;
+		for (auto node : this->next->tree) {
+			auto file_name_size = node->file->GetName().size();
+			auto file_str_len = file_name_size * 2 + 1;
+			space += sizeof(FileIdentifierDescriptor) - 1 + file_str_len + (file_name_size % 2) * 2;
+		}
+	}
+	return std::ceil(space / 2048.0);
+}

--- a/PS2ImageMaker/Directory.h
+++ b/PS2ImageMaker/Directory.h
@@ -30,6 +30,7 @@ struct FileTreeNode {
 	int links; // Amount of links to another directories
 	int depth;
 	FileTreeNode(FileTree* next, FileTreeNode* parent, File* file) : next(next), parent(parent), file(file), depth(0), links(1) {}
+	unsigned int get_directory_records_space();
 };
 
 struct FileTree {
@@ -40,11 +41,15 @@ struct FileTree {
 	long get_content_amount();
 	long get_dir_links();
 	unsigned int get_files_size();
+	unsigned int get_directory_records_amount();
+	unsigned int get_file_identifiers_amount();
 
 private:
 	void _get_dir_amount(FileTreeNode* node, long& amount);
 	void _get_file_amount(FileTreeNode* node, long& amount);
 	void _get_files_size(FileTreeNode* node, unsigned int& size);
+	void _get_directory_records_amount(FileTreeNode* node, unsigned int& amount);
+	void _get_file_identifiers_amount(FileTreeNode* node, unsigned int& amount);
 };
 
 class Directory

--- a/PS2ImageMaker/Directory.h
+++ b/PS2ImageMaker/Directory.h
@@ -31,6 +31,7 @@ struct FileTreeNode {
 	int depth;
 	FileTreeNode(FileTree* next, FileTreeNode* parent, File* file) : next(next), parent(parent), file(file), depth(0), links(1) {}
 	unsigned int get_directory_records_space();
+	unsigned int get_file_identifiers_space();
 };
 
 struct FileTree {

--- a/PS2ImageMaker/PS2ImageMaker.vcxproj
+++ b/PS2ImageMaker/PS2ImageMaker.vcxproj
@@ -17,6 +17,14 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="RelWithDebugInfo|Win32">
+      <Configuration>RelWithDebugInfo</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="RelWithDebugInfo|x64">
+      <Configuration>RelWithDebugInfo</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
@@ -32,6 +40,12 @@
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -42,6 +56,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -60,10 +80,16 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -74,12 +100,19 @@
     <LinkIncremental>true</LinkIncremental>
     <TargetName>$(ProjectName)</TargetName>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <TargetName>$(ProjectName)</TargetName>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <ExtensionsToDeleteOnClean>$(ExtensionsToDeleteOnClean)</ExtensionsToDeleteOnClean>
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -92,6 +125,21 @@
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;PS2IMAGEMAKER_EXPORTS;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;PS2IMAGEMAKER_EXPORTS;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -126,6 +174,21 @@
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;PS2IMAGEMAKER_EXPORTS;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>PS2IMAGEMAKER_EXPORTS;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -172,7 +235,9 @@
     <ClCompile Include="File.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>

--- a/PS2ImageMaker/SectorManager.cpp
+++ b/PS2ImageMaker/SectorManager.cpp
@@ -21,6 +21,7 @@ along with this program.If not, see < https://www.gnu.org/licenses/>.
 #include "Directory.h"
 #include "File.h"
 #include <algorithm>
+#include <regex>
 
 SectorManager::SectorManager(FileTree* ft) : current_sector(0L), data_sector(261L), total_sectors(0)
 {
@@ -57,29 +58,21 @@ SectorManager::SectorManager(FileTree* ft) : current_sector(0L), data_sector(261
 	unsigned int data_sec = this->data_sector;
 	unsigned int data_lba = dir_lba + this->directories_amount;
 	unsigned int file_local_sector = this->data_sector - 261 - directory_records;
-	for (auto i = 0; i < this->directories_amount; ++i) {
-		for (auto node : cur_tree->tree) {
-			if (!node->file->IsDirectory()) {
-				auto vec_iter = std::find_if(file_sectors.begin(), file_sectors.end(), [node](std::pair<FileTreeNode*, FileLocation> p) {
-					return p.first == node;
-				});
-				this->files.push_back(node);
-				(*vec_iter).second.global_sector = data_sec;
-				(*vec_iter).second.lba = data_lba++;
-				(*vec_iter).second.local_sector = file_local_sector;
-				auto sector_space = 0;
-				if ((*vec_iter).first->file->GetSize() % 2048 != 0) {
-					sector_space = ((*vec_iter).first->file->GetSize() + (2048 - (*vec_iter).first->file->GetSize() % 2048)) / 2048;
-				}
-				else {
-					sector_space = (*vec_iter).first->file->GetSize() / 2048;
-				}
-				data_sec += sector_space;
-				file_local_sector += sector_space;
+	for (auto& p : file_sectors) {
+		if (!p.first->file->IsDirectory()) {
+			this->files.push_back(p.first);
+			p.second.global_sector = data_sec;
+			p.second.lba = data_lba++;
+			p.second.local_sector = file_local_sector;
+			auto sector_space = 0;
+			if (p.first->file->GetSize() % 2048 != 0) {
+				sector_space = (p.first->file->GetSize() + (2048 - p.first->file->GetSize() % 2048)) / 2048;
 			}
-		}
-		if (i != this->directories_amount - 1) {
-			cur_tree = this->directories[i]->next;
+			else {
+				sector_space = p.first->file->GetSize() / 2048;
+			}
+			data_sec += sector_space;
+			file_local_sector += sector_space;
 		}
 	}
 }
@@ -109,11 +102,8 @@ void SectorManager::write_file(FILE* out_f, FILE* in_f, void* buf, long file_siz
 void SectorManager::pad_sector(FILE* f, int padding_size)
 {
 	// Pad to align the sector
-	auto pad = '\0';
-	auto leftover = padding_size;
-	for (int i = 0; i < leftover; ++i) {
-		fwrite(&pad, 1, 1, f);
-	}
+	auto pad = new char[padding_size]();
+	fwrite(pad, 1, padding_size, f);
 }
 
 unsigned int SectorManager::get_total_sectors()
@@ -190,9 +180,25 @@ void SectorManager::_fill_file_sectors(FileTree* ft, bool root)
 	}
 	// Need to sort the map but only by the initial caller
 	if (!root) return;
-	// Sort by depth
-	std::sort(file_sectors.begin(), file_sectors.end(), [](std::pair<FileTreeNode*, FileLocation> f1, std::pair<FileTreeNode*, FileLocation>  f2) {
-		return f1.first->depth < f2.first->depth;
+	// Sort by depth and name
+	std::sort(file_sectors.begin(), file_sectors.end(), [](std::pair<FileTreeNode*, FileLocation> dir1, std::pair<FileTreeNode*, FileLocation> dir2) {
+		auto dir1_path = dir1.first->file->GetPath();
+		auto dir2_path = dir2.first->file->GetPath();
+
+		if (dir1.first->depth == dir2.first->depth) {
+			std::regex regexp("[\\\\/]");
+			std::sregex_token_iterator dir1_match(dir1_path.begin(), dir1_path.end(), regexp, -1);
+			std::sregex_token_iterator dir2_match(dir2_path.begin(), dir2_path.end(), regexp, -1);
+			std::sregex_token_iterator end;
+			while (dir1_match != end && dir2_match != end) {
+				if (strcmp((*dir1_match).str().c_str(), (*dir2_match).str().c_str()) != 0) {
+					return strcmp((*dir1_match).str().c_str(), (*dir2_match).str().c_str()) < 0;
+				}
+				dir1_match++;
+				dir2_match++;
+			}
+		}
+		return dir1.first->depth < dir2.first->depth;
 	});
 	unsigned int directory_record_sector = 262;
 	unsigned int dir_lba = 3 + ft->get_file_identifiers_amount(); // Directory LBA starts 2 sectors from FileSetDescriptor + 1 since we record root in code later

--- a/Test/Test.vcxproj
+++ b/Test/Test.vcxproj
@@ -17,6 +17,14 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="RelWithDebugInfo|Win32">
+      <Configuration>RelWithDebugInfo</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="RelWithDebugInfo|x64">
+      <Configuration>RelWithDebugInfo</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
@@ -32,6 +40,12 @@
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -40,6 +54,12 @@
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
@@ -60,10 +80,16 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -74,16 +100,38 @@
     <LinkIncremental>true</LinkIncremental>
     <TargetName>$(ProjectName)</TargetName>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <TargetName>$(ProjectName)</TargetName>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>D:\Programming\GitHub-repos\PS2ImageMaker\PS2ImageMaker</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>D:\Programming\GitHub-repos\PS2ImageMaker\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>PS2ImageMaker.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
@@ -118,6 +166,21 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>D:\Programming\GitHub-repos\PS2ImageMaker\PS2ImageMaker</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>D:\Programming\GitHub-repos\PS2ImageMaker\x64\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>PS2ImageMaker.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebugInfo|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>


### PR DESCRIPTION
Fixes issues with games having a lot of files and directories in a single directory which makes Directory record and File Identifier Descriptors span into multiple logical sectors which would throw all calculations in a complete mess.